### PR TITLE
fix: add article ownership checks

### DIFF
--- a/controllers/articleController.js
+++ b/controllers/articleController.js
@@ -575,19 +575,32 @@ module.exports.getArticleTranslations = expressAsyncHandler(
 module.exports.updateArticle = expressAsyncHandler(
   async (req, res) => {
     try {
-      const article = await Article.findByIdAndUpdate(req.params.id, req.body, {
-        new: true,
-      }).populate('tags') // This populates the tag data
-        .exec();
-      if (!article) {
-        return res.status(404).json({ message: "Article not found" });
+      const existingArticle = await Article.findById(req.params.id);
+
+      if (!existingArticle) {
+        return res.status(404).json({message: "Article not found"});
       }
-      // await article.save();
-      res.status(200).json({ message: "Article updated successfully", article });
+
+      if (existingArticle.authorId.toString() !== req.userId.toString()) {
+        return res.status(403).json({message: "Forbidden"});
+      }
+
+      const article = await Article.findByIdAndUpdate(
+        req.params.id,
+        req.body,
+        {new: true}
+      )
+        .populate('tags')
+        .exec();
+
+      res.status(200).json({
+        message: "Article updated successfully",
+        article
+      });
     } catch (error) {
       res
         .status(500)
-        .json({ error: "Error updating article", details: error.message });
+        .json({error: "Error updating article", details: error.message});
     }
   }
 )
@@ -596,17 +609,23 @@ module.exports.updateArticle = expressAsyncHandler(
 module.exports.deleteArticle = expressAsyncHandler(
   async (req, res) => {
     try {
-      const article = await Article.findByIdAndDelete(req.params.id)
-        .populate('tags') // This populates the tag data
-        .exec();
-      if (!article) {
-        return res.status(404).json({ message: "Article not found" });
+      const existingArticle = await Article.findById(req.params.id);
+
+      if (!existingArticle) {
+        return res.status(404).json({message: "Article not found"});
       }
-      res.status(200).json({ message: "Article deleted successfully" });
+
+      if (existingArticle.authorId.toString() !== req.userId.toString()) {
+        return res.status(403).json({message: "Forbidden"});
+      }
+
+      await Article.findByIdAndDelete(req.params.id);
+
+      res.status(200).json({message: "Article deleted successfully"});
     } catch (error) {
       res
         .status(500)
-        .json({ error: "Error deleting article", details: error.message });
+        .json({error: "Error deleting article", details: error.message});
     }
   }
 )


### PR DESCRIPTION
#### PR Description

This PR fixes an authorization vulnerability in the article update and delete endpoints.

Previously, the `PUT /api/articles/:id` and `DELETE /api/articles/:id` endpoints authenticated the user but did not verify whether the authenticated user actually owned the article. This allowed any authenticated user who knew an article ID to potentially modify or delete another user's article.

The fix adds an explicit ownership check before performing either operation.

For both endpoints:
- The article is first fetched using its ID.
- A `404 Not Found` response is returned if the article does not exist.
- The authenticated user's `req.userId` is compared with the article's `authorId`.
- A `403 Forbidden` response is returned when the authenticated user is not the article owner.
- The update/delete operation proceeds only after ownership is verified.

This ensures that authenticated users can only modify or delete articles they own.

#### Type of Change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area

- [ ] Frontend
- [x] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue

#2224

#### Add your Work Example

📷 Add a Snapshot

Not applicable — this is a backend security/authorization fix with no visual UI changes.

#### Fixes (mention the issue number which this fixes)

#2224

#### Checklist

- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree