### PR TITLE
fix: saveArticle already-saved check misses type coercion — cannot unsave (#25)

### DIFF
--- a/controllers/articleController.js
+++ b/controllers/articleController.js
@@ -665,7 +665,10 @@ module.exports.saveArticle = expressAsyncHandler(
       // Check if the article is already saved
       //const isArticleSaved = user.savedArticles.includes(id => id === article_id);
       const savedArticlesSet = new Set(user.savedArticles);
-      const isArticleSaved = savedArticlesSet.has(article_id);
+      // savedArticles is [Number], so coerce (article_id often arrives as a
+      // string) — without this the check is always false and unsave is
+      // unreachable. Matches likeArticle's Number(article_id) usage.
+      const isArticleSaved = savedArticlesSet.has(Number(article_id));
 
       if (isArticleSaved) {
 


### PR DESCRIPTION
Fixes #25

### Problem
`user.savedArticles` is typed `[Number]` (`models/UserModel.js`), but `saveArticle` checked `savedArticlesSet.has(article_id)` with `article_id` taken straight from `req.body`. When the client sends it as a **string**, `Set<number>.has("123")` is always `false`, so the endpoint always takes the "else" branch and responds "Article saved successfully" — the unsave path is unreachable (`$addToSet` hides the DB duplication, so it looks like a stuck toggle).

### Fix
Coerce with `Number(article_id)` in the `has()` check, matching the sibling `likeArticle` handler which already does `likedArticlesSet.has(Number(article_id))`.

Passes `node --check`.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._