### PR TITLE
fix: duplicate getAllTags export shadows the published-tags implementation (#24)

### DIFF
--- a/controllers/articleController.js
+++ b/controllers/articleController.js
@@ -1244,17 +1244,6 @@ module.exports.trustArticle = expressAsyncHandler(
 );
 
 // Get all tags
-module.exports.getAllTags = expressAsyncHandler(
-  async (req, res) => {
-    try {
-      const allTags = await ArticleTag.find().sort({ id: -1 }).lean();
-      res.status(200).json(allTags);
-    } catch (err) {
-      res.status(500).json({ error: err.message });
-    }
-  }
-)
-
 // Get trusted users for an article
 module.exports.getTrustedUsers = expressAsyncHandler(
   async (req, res) => {


### PR DESCRIPTION
Fixes #24

### Problem
`controllers/articleController.js` defined `module.exports.getAllTags` **twice** (`:873` and `:1247`). The later definition (returns **all** `ArticleTag`s) overwrote the earlier, intended one (only tags used by **PUBLISHED** articles, de-duped and recency-ordered), so `GET /articles/tags` (`routes/articleRoutes.js:121`) always ran the all-tags version — returning every tag ever created, including tags with no published articles — and edits to the first function had no effect.

### Fix
Removed the duplicate (`:1247`) so the curated published-tags implementation is the one exported.

Passes `node --check`; a single `getAllTags` export now remains.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._