### PR TITLE
fix: glossary createTerm must use the authenticated admin as author (#23)

### DIFF
--- a/controllers/glossaryController.js
+++ b/controllers/glossaryController.js
@@ -4,7 +4,10 @@ const { throwError } = require('../utils/throwError');
 
 module.exports.createTerm = expressAsyncHandler(async (req, res) => {
 
-  const authorId = req.user ? req.userId: req.body.authorId; 
+  // adminAuthenticateToken sets req.userId (never req.user), so the author must
+  // come from the authenticated admin — never from a client-supplied body field,
+  // which would let anyone spoof authorship.
+  const authorId = req.userId;
   const data = { ...req.validateBody, authorId };
   
   const term = await glossaryService.createTerm(data);


### PR DESCRIPTION
Closes #23

### The bug
`controllers/glossaryController.js`:

```js
const authorId = req.user ? req.userId : req.body.authorId;
```

The route (`routes/glossaryRoutes.js`) uses `adminAuthenticateToken`, which sets **`req.userId`** and never `req.user` (`middleware/adminAuthenticateToken.js:26`). So `req.user` is always falsy → `authorId = req.body.authorId` on every request.

**Impact:** the authenticated admin’s identity is never used; a glossary term is attributed to whatever `authorId` the client sends (or `undefined` if omitted). Authorship is spoofable and the real creator is never recorded — a data-integrity / attribution bug.

### The fix
Take `authorId` from `req.userId` (the authenticated admin) unconditionally.

> Note: the repo currently has no test harness (`package.json` `test` is a placeholder and there are no spec files), so this ships as the one-line fix with `node -c` syntax verification rather than pulling in a full test framework for a single line. Happy to add tests if you would like to set up jest/supertest.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._